### PR TITLE
HEADERS: add cache-control for responses

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,7 +3,7 @@
 reverse_proxy /api* {
   to {$BACKEND_URI}
   header_up Host {http.reverse_proxy.upstream.host}
-  header_up Cache-Control "no-cache, no-store"
+  header_down Cache-Control "no-cache, no-store"
   header_down X-Content-Type-Options "nosniff"
   header_down X-XSS-Protection "1; mode=block"
 }
@@ -12,6 +12,7 @@ reverse_proxy localhost:3000 {
   header_down X-FRAME-Options "DENY"
   header_down Content-Security-Policy "frame-ancestors 'none'"
   header_down Strict-Transport-Security "max-age=31536000; includeSubDomains"
+  header_down Cache-Control "no-cache, no-store"
   header_down X-Content-Type-Options "nosniff"
   header_down X-XSS-Protection "1; mode=block"
 }


### PR DESCRIPTION
members.legalplans.com is still sending responses without the `cache-control` header. I think this will fix it, but wasn't sure about flipping `header_up` to `header_down`

![Screenshot from 2020-10-09 09-17-33](https://user-images.githubusercontent.com/640862/95607301-624e8680-0a10-11eb-98f3-a21f630740fa.png)
